### PR TITLE
Add a test that shows the config file can be extended

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,82 @@ def vars_read_for_work(
 
 
 @pytest.fixture
-def config_file_path() -> Path:
-    """Defines a system path to the config file."""
+def config_file_path(
+        test_config_file_path: Path,
+        work_config_file_path: Path
+) -> Path:
+    """Checks both files and defines an existing config file."""
+    if work_config_file_path.is_file():
+        return work_config_file_path
+
+    return test_config_file_path
+
+
+@pytest.fixture
+def test_config_file_path() -> Path:
+    """Defines a system path to the config file for tests."""
     test_config_file = DIR_APP / "example_vars.ini"
-    work_config_file = DIR_APP / "vars.ini"
-    if work_config_file.is_file():
-        return work_config_file
+
     return test_config_file
+
+
+@pytest.fixture
+def work_config_file_path() -> Path:
+    """Defines a system path to the config file for work."""
+    work_config_file_path = DIR_APP / "vars.ini"
+    return work_config_file_path
+
+
+@pytest.fixture
+def added_vars_read_for_test(
+    test_config_file_path: Path,
+) -> list:
+    """Add some variables and matches them for the test."""
+    with open(test_config_file_path, "w", encoding="utf-8") as file:
+        test_vars_values = []
+        lines = file.split("\n")
+        for line in file:
+            if "192." in line:
+                added_line = "TEST_999 = 192.168.125.100"
+                test_vars_values.append(added_line)
+            test_vars_values.append(line.replace("\n", ""))
+    with open(test_config_file_path, "r", encoding="utf-8") as file:
+        test_vars_values = []
+        for line in file:
+            if line.startswith(";") or line.startswith("["):
+                continue
+            if line == "\n":
+                continue
+            line = line.split(" = ")[1]
+
+            test_vars_values.append(line.replace("\n", ""))
+
+    return test_vars_values
+
+
+@pytest.fixture
+def added_vars_read_for_work(
+    config_file_path: Path,
+) -> list:
+    """Add some variables and matches them for the project."""
+    config_vars = Vars(config_file_path)
+    allvars_attrs = dir(config_vars)
+    project_vars = []
+
+    for attr in allvars_attrs:
+        if attr.startswith("__"):
+            continue
+        if attr in ("sendings", "read_configs"):
+            continue
+
+        project_vars.append(getattr(config_vars, attr))
+
+    _vars = str(project_vars)
+    vars_values = re.sub(r"'[^']*':", "", _vars, flags=re.DOTALL)
+    vars_values = re.sub(r"[\[\]]|\{|}", "", vars_values)
+    vars_values = re.sub(r"'", "", vars_values)
+    vars_values = re.sub(r"^\s+", "", vars_values)
+    vars_values = re.sub(r",\s+", ",", vars_values)
+    work_vars_values = vars_values.split(",")
+
+    return work_vars_values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def working_config_file_path() -> Path:
 
 
 @pytest.fixture
-def extended_config_file_path(example_config_file_path: Path):git
+def extended_config_file_path(example_config_file_path: Path):
     """
     Extends the example config file with a few parameters.
     Returns the system path to the file.

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -9,11 +9,7 @@ def test_config_file_has_completely_read(
     vars_read_for_work: list,
 ) -> None:
     """Checks the vars number and weather they've been completely read."""
-
     for var in vars_read_for_test:
         assert var in vars_read_for_work
-
-    for _ in range(len(vars_read_for_test)):
-        print(vars_read_for_work[_])
 
     assert len(vars_read_for_work) == len(vars_read_for_test)


### PR DESCRIPTION
 - Add a function that adds a few test parameters to the config file;
 - Add a function that removes the just-added parameters after the test is passed;
 - Devide the fixture that returns the config file path into three fixtures for more flexible use;
 - Change the fixture to choose which path to use;
 - Add a fixture with a couple of parameters to run the test function twice: with the original config file and with the extended config file.
 Now the test function is running twice.