### PR TITLE
Fix bug (issue-28: ini file is not found from exe file).

### DIFF
--- a/app/builder.py
+++ b/app/builder.py
@@ -17,6 +17,8 @@ def glue_scripts(
                 for line in lines:
                     if "app." in line or '"""' in line:
                         continue
+                    if "FILE_VARS = DIR_APP / " in line:
+                        line = line.replace("DIR_APP / ", "")
                     if "__name__" in line:
                         break
                     out.write(line)

--- a/app/vars.py
+++ b/app/vars.py
@@ -17,7 +17,7 @@ class IniSection(configparser.ConfigParser):
 class Vars:
     """Keeps all the config variables."""
 
-    def __init__(self, config_file: Path) -> None:
+    def __init__(self, config_file: Path | str) -> None:
         """Reads the variables from a config file."""
         configs = IniSection()
         configs.read(config_file, "utf-8")


### PR DESCRIPTION
The config file ```vars.ini``` relative path definition is replaced with just the name of the file that should be located in the same folder as ```CheckServer.exe``` file.