### PR TITLE
Add a test that depending on where the tests are run, the required configuration file is used

### DIFF
--- a/tests/test_1_read_config.py
+++ b/tests/test_1_read_config.py
@@ -103,9 +103,11 @@ def test_invalid_ip_is_detected(extended_config_file_path: Path) -> None:
                 assert ipaddress.ip_address(host)
 
 
-def test_right_config_file_chosen():
+def test_right_config_file_chosen() -> None:
     """Checks whether the right configuration file is used."""
+
     if GITHUB_ROOTDIR in str(DIR_ROOT):
         assert "example_vars.ini" in str(FILE_VARS)
+
     else:
         assert "vars.ini" in str(FILE_VARS)

--- a/tests/test_1_read_config.py
+++ b/tests/test_1_read_config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 import validators
 
+from app.dirs import DIR_ROOT, FILE_VARS, GITHUB_ROOTDIR
 from app.vars import Vars
 
 
@@ -100,3 +101,11 @@ def test_invalid_ip_is_detected(extended_config_file_path: Path) -> None:
             ip_mask = re.search(r"(.{1,3}\.){3}", host)
             if ip_mask:
                 assert ipaddress.ip_address(host)
+
+
+def test_right_config_file_chosen():
+    """Checks whether the right configuration file is used."""
+    if GITHUB_ROOTDIR in str(DIR_ROOT):
+        assert "example_vars.ini" in str(FILE_VARS)
+    else:
+        assert "vars.ini" in str(FILE_VARS)


### PR DESCRIPTION
Closes #70 
#### Description:
-  Check the platform comparing thre paths.
-  Check whether the needed configuration file is used.
