### PR TITLE
Fix an error when removing a network from the config file.

### DIFF
--- a/.github/settings/.pylintrc
+++ b/.github/settings/.pylintrc
@@ -3,4 +3,5 @@ ignore = commons.py, try.py
 
 [MESSAGES CONTROL]
 disable = too-few-public-methods,
-          redefined-outer-name
+          redefined-outer-name,
+          too-many-instance-attributes

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ auditor = AuditShields(all_vars)
 
 while True:
 
-    for net_ in ["WIFI", "DLAN", "INET"]:
+    for net_ in all_vars.nets:
         if not auditor.is_network_out(net_):
             auditor.check_shields(net_)
 

--- a/app/vars.py
+++ b/app/vars.py
@@ -46,7 +46,6 @@ class Vars:
                 if net in header:
                     self.nets.append(net)
                     break
-        # self.nets = [header for header in headers for net in nets if net in header]
 
 
 if __name__ == "__main__":

--- a/app/vars.py
+++ b/app/vars.py
@@ -40,6 +40,7 @@ class Vars:
         self.messages = {
             source: configs["MESSAGES"][f"{source}"] for source in self.hosts
         }
+        self.nets = [net for net in nets if net in headers]
 
 
 if __name__ == "__main__":

--- a/app/vars.py
+++ b/app/vars.py
@@ -40,7 +40,13 @@ class Vars:
         self.messages = {
             source: configs["MESSAGES"][f"{source}"] for source in self.hosts
         }
-        self.nets = [net for net in nets if net in headers]
+        self.nets = []
+        for header in headers:
+            for net in nets:
+                if net in header:
+                    self.nets.append(net)
+                    break
+        # self.nets = [header for header in headers for net in nets if net in header]
 
 
 if __name__ == "__main__":

--- a/app/vars.py
+++ b/app/vars.py
@@ -41,8 +41,8 @@ class Vars:
             source: configs["MESSAGES"][f"{source}"] for source in self.hosts
         }
         self.nets = []
-        for header in headers:
-            for net in nets:
+        for net in nets:
+            for header in headers:
                 if net in header:
                     self.nets.append(net)
                     break
@@ -59,5 +59,6 @@ if __name__ == "__main__":
         all_vars.hosts,
         all_vars.sendings,
         all_vars.messages,
+        all_vars.nets,
         sep="\n",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,17 +161,24 @@ def bad_hosts_vars(config_vars_set: Vars) -> Vars:
     all_vars = config_vars_set
     all_hosts = str(all_vars.hosts)
 
-    any_host = "[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}"
+    any_host = r"(\d{1,3}\.){3}\d{1,3}"
     never_reached_host = "192.0.2.1"
     bad_hosts = re.sub(any_host, never_reached_host, all_hosts)
 
     all_vars.hosts = ast.literal_eval(bad_hosts)
+
+    always_available_host = 'www.google.com'
+    for shield, hosts in all_vars.hosts.items():
+        for name, host in hosts.items():
+            if "IN_TOUCH" in name:
+                hosts[name] = always_available_host
 
     viber_admin = {
         vb_user: vb_id
         for vb_user, vb_id in all_vars.viber_users.items()
         if vb_user == "Admin"
     }
+
     telegram_admin = {
         tg_user: tg_id
         for tg_user, tg_id in all_vars.telegram_users.items()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,9 +167,9 @@ def bad_hosts_vars(config_vars_set: Vars) -> Vars:
 
     all_vars.hosts = ast.literal_eval(bad_hosts)
 
-    always_available_host = 'www.google.com'
-    for shield, hosts in all_vars.hosts.items():
-        for name, host in hosts.items():
+    always_available_host = "www.google.com"
+    for hosts in all_vars.hosts.values():
+        for name in hosts.keys():
             if "IN_TOUCH" in name:
                 hosts[name] = always_available_host
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,27 +40,28 @@ def vars_read_for_work(
 ) -> list:
     """Matches variables read from the config file for the project."""
 
-    config_path = total_config_file_path
+    config_vars = Vars(total_config_file_path)
 
-    config_vars = Vars(config_path)
-    allvars_attrs = dir(config_vars)
-    project_vars = []
+    telegram_ids = config_vars.telegram_users.values()
+    viber_ids = config_vars.viber_users.values()
+    telegram_settings = config_vars.telegram_configs.values()
+    viber_settings = config_vars.viber_configs.values()
+    messages = config_vars.messages.values()
+    hosts = [
+        hosts for host in config_vars.hosts.values() for hosts in host.values()
+    ]
+    vars_values = [
+        telegram_ids,
+        viber_ids,
+        telegram_settings,
+        viber_settings,
+        messages,
+        hosts,
+    ]
 
-    for attr in allvars_attrs:
-        if attr.startswith("__"):
-            continue
-        if attr in ("sendings", "read_configs"):
-            continue
-
-        project_vars.append(getattr(config_vars, attr))
-
-    _vars = str(project_vars)
-    vars_values = re.sub(r"'[^']*':", "", _vars, flags=re.DOTALL)
-    vars_values = re.sub(r"[\[\]]|\{|}", "", vars_values)
-    vars_values = re.sub(r"'", "", vars_values)
-    vars_values = re.sub(r"^\s+", "", vars_values)
-    vars_values = re.sub(r",\s+", ",", vars_values)
-    work_vars_values = vars_values.split(",")
+    work_vars_values = [
+        list_items for lists in vars_values for list_items in lists
+    ]
 
     return work_vars_values
 

--- a/tests/test_1_check_config.py
+++ b/tests/test_1_check_config.py
@@ -113,10 +113,16 @@ def test_right_config_file_chosen() -> None:
         assert "vars.ini" in str(FILE_VARS)
 
 
-def each_shield_has_a_corresponding_message(config_vars_set: Vars) -> None:
+def test_shields_have_corresponding_messages(config_vars_set: Vars) -> None:
     """Finds a message text that corresponds a certain shield."""
 
     shields = list(config_vars_set.hosts.keys())
     pointers = list(config_vars_set.messages.keys())
 
     assert shields == pointers
+
+
+def test_neded_vars_exist(config_vars_set: Vars) -> None:
+    """Checks if all the necessary variables are collected."""
+
+    assert config_vars_set.nets

--- a/tests/test_2_check_pinging.py
+++ b/tests/test_2_check_pinging.py
@@ -14,9 +14,8 @@ def test_base_ping_settings_work_fine(config_vars_set: Vars) -> None:
     """Checks the project's ping job using always in touch server."""
 
     vars_ = config_vars_set
-    inet_hosts = vars_.hosts["INET SOURCE"]
     audit_shields = AuditShields(vars_)
-    in_touch_host = inet_hosts["IN_TOUCH"]
+    in_touch_host = "www.google.com"
     is_host_out = audit_shields.ping_host(in_touch_host)
 
     assert is_host_out is False

--- a/tests/test_5_check_allbots.py
+++ b/tests/test_5_check_allbots.py
@@ -36,8 +36,8 @@ def test_alarm_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
     """
     auditor = AuditShields(bad_hosts_vars)
 
-    for net in ["WIFI", "DLAN", "INET"]:
-        if not auditor.is_network_out("INET"):
+    for net in bad_hosts_vars.nets:
+        if not auditor.is_network_out(net):
             power_off_shields = auditor.check_shields(net)
             the_values = power_off_shields.values()
             assert all(the_values) is True


### PR DESCRIPTION
Closes #74
#### Description:
 - Replace the static definition of the network list with a dynamic one, depending on which networks the user selected in the configuration file.
 - Fix the regular expressions when finding IP addresses.
 - Set the 'always in touch' host as 'www.google.com' for the tests.