### PR TITLE
Fix the tests that check whether a message, once sent will not be sent twice.

### DIFF
--- a/app/audit.py
+++ b/app/audit.py
@@ -155,28 +155,36 @@ class AuditShields:
 
         return False
 
-    def set_alarm_sending_status(self) -> None:
+    def set_alarm_sending_status(self) -> bool:
         """
         Sets a sending status
         if an alarm message is sent.
         """
 
+        statuses_have_been_changed = False
         for shield, status in self.power_off_shields.items():
             if not status:
                 continue
             if not self.vars.alarm_sendings[shield]:
                 self.vars.alarm_sendings[shield] = True
                 self.vars.cancel_sendings[shield] = False
+                statuses_have_been_changed = True
 
-    def set_cancel_sending_status(self) -> None:
+        return statuses_have_been_changed
+
+    def set_cancel_sending_status(self) -> bool:
         """
         Sets a sending status
         if a cancel message is sent.
         """
 
+        statuses_have_been_changed = False
         for shield, status in self.power_on_shields.items():
             if not status:
                 continue
             if not self.vars.cancel_sendings[shield]:
                 self.vars.cancel_sendings[shield] = True
                 self.vars.alarm_sendings[shield] = False
+                statuses_have_been_changed = True
+
+        return statuses_have_been_changed

--- a/tests/test_5_check_allbots.py
+++ b/tests/test_5_check_allbots.py
@@ -26,7 +26,7 @@ def test_one_of_bots_in_use(
 
 
 @pytest.mark.skipif(
-    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="Denied to ping from GitHub"
+    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="Denied pinging from GitHub"
 )
 def test_alarm_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
     """
@@ -86,30 +86,6 @@ def test_cancel_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
     Checks the sent message doesn't send twice.
     """
     auditor = AuditShields(bad_hosts_vars)
-
-    for shield in bad_hosts_vars.hosts.keys():
-        auditor.power_off_shields.update({shield: True})
-
-    assert all(auditor.power_off_shields.values()) is True
-
-    alarm_message = auditor.form_alarm_message()
-    assert alarm_message
-
-    first_alarm_message = auditor.send_messages(alarm_message)
-    assert first_alarm_message is True
-
-    auditor.set_alarm_sending_status()
-
-    for shield in bad_hosts_vars.alarm_sendings.keys():
-        if "SOURCE" in shield:
-            continue
-        assert bad_hosts_vars.alarm_sendings[shield] is True
-
-    rematched_message = auditor.form_alarm_message()
-    assert not rematched_message
-
-    second_alarm_message = auditor.send_messages(rematched_message)
-    assert second_alarm_message is False
 
     for shield in bad_hosts_vars.hosts.keys():
         auditor.power_on_shields.update({shield: True})

--- a/tests/test_5_check_allbots.py
+++ b/tests/test_5_check_allbots.py
@@ -1,11 +1,6 @@
 """Telegram and Viber bots checking."""
 
-import pytest
-
-from app.audit import AuditShields
-from app.dirs import DIR_ROOT, GITHUB_ROOTDIR
 from app.telegram import MyTelegramBot
-from app.vars import Vars
 from app.viber import MyViberBot
 
 
@@ -23,93 +18,3 @@ def test_one_of_bots_in_use(
     """
 
     assert any([telebot_in_use, viberbot_in_use]), err_msg
-
-
-@pytest.mark.skipif(
-    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="Denied pinging from GitHub"
-)
-def test_emergency_message_sent(bad_hosts_vars: Vars) -> None:
-    """
-    Checks all the test hosts are unreached.
-    Checks the ping command number is equal the hosts number.
-    Checks the result message has been sent.
-    Checks that the message once sent, doesn't send twice.
-    """
-    auditor = AuditShields(bad_hosts_vars)
-
-    assert all(auditor.power_off_shields.values()) is False
-
-    for net in bad_hosts_vars.nets:
-        if not auditor.is_network_out(net):
-            auditor.check_shields(net)
-
-    assert all(auditor.power_off_shields.values()) is True
-
-    alarm_message = auditor.form_alarm_message()
-    all_hosts_list = [
-        hosts
-        for hosts in bad_hosts_vars.hosts.values()
-        if "IN_TOUCH" not in hosts.keys()
-    ]
-    all_hosts_number = sum(len(host) for host in all_hosts_list)
-
-    assert auditor.pinged_hosts == all_hosts_number
-
-    first_alarm_message = auditor.send_messages(alarm_message)
-
-    assert first_alarm_message is True
-
-    status = auditor.set_alarm_sending_status()
-
-    assert status is True
-
-    for shield in bad_hosts_vars.alarm_sendings.keys():
-        if "SOURCE" in shield:
-            continue
-        assert bad_hosts_vars.alarm_sendings[shield] is True
-
-    rematched_message = auditor.form_alarm_message()
-
-    assert not rematched_message
-
-    second_alarm_message = auditor.send_messages(rematched_message)
-
-    assert second_alarm_message is False
-
-
-@pytest.mark.skipif(
-    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="No credentials on GitHub"
-)
-def test_cancel_message_sent(bad_hosts_vars: Vars) -> None:
-    """
-    Sets all the test hosts status as if they are available again.
-    Just setting without pinging.
-    Checks the result message has been sent.
-    Checks that the message, once sent doesn't send twice.
-    """
-    auditor = AuditShields(bad_hosts_vars)
-    for shield in bad_hosts_vars.hosts.keys():
-        auditor.power_on_shields.update({shield: True})
-
-    assert all(auditor.power_on_shields.values()) is True
-
-    cancel_message = auditor.form_cancel_message()
-    first_cancel_message = auditor.send_messages(cancel_message)
-
-    assert first_cancel_message is True
-
-    status = auditor.set_cancel_sending_status()
-
-    assert status is True
-
-    for shield in bad_hosts_vars.cancel_sendings.keys():
-        if "SOURCE" in shield:
-            continue
-        assert bad_hosts_vars.cancel_sendings[shield] is True
-
-    rematched_message = auditor.form_cancel_message()
-
-    assert not rematched_message
-
-    second_cancel_message = auditor.send_messages(rematched_message)
-    assert second_cancel_message is False

--- a/tests/test_5_check_allbots.py
+++ b/tests/test_5_check_allbots.py
@@ -49,12 +49,6 @@ def test_alarm_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
     result_message = auditor.form_alarm_message()
     assert result_message
 
-    for shield in bad_hosts_vars.hosts.keys():
-        if "SOURCE" in shield:
-            continue
-        assert bad_hosts_vars.alarm_messages[shield] in result_message
-        assert bad_hosts_vars.alarm_sendings[shield] is False
-
     all_hosts_list = [
         hosts
         for hosts in bad_hosts_vars.hosts.values()
@@ -81,75 +75,62 @@ def test_alarm_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
     assert twice_sent_message is False
 
 
-# @pytest.mark.skipif(
-#     GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="No credentials on GitHub"
-# )
-# def test_cancel_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
-#     """
-#     Sets all the test hosts as unreached and available again.
-#     Just sets without pinging.
-#     Checks the result message contains all the information needed.
-#     Checks the result message has been sent.
-#     Checks the sent message doesn't send twice.
-#     """
-#     auditor = AuditShields(bad_hosts_vars)
-#
-#     for shield in bad_hosts_vars.hosts.keys():
-#         auditor.power_off_shields.update({shield: True})
-#
-#     assert all(auditor.power_off_shields.values()) is True
-#
-#     alarm_message = auditor.form_alarm_message()
-#     assert alarm_message
-#
-#     for shield in bad_hosts_vars.hosts.keys():
-#         if "SOURCE" in shield:
-#             continue
-#         assert bad_hosts_vars.alarm_messages[shield] in alarm_message
-#         assert bad_hosts_vars.alarm_sendings[shield] is False
-#
-#     once_sent_message = auditor.send_messages(alarm_message)
-#     assert once_sent_message is True
-#
-#     auditor.set_alarm_sending_status()
-#
-#     for shield in bad_hosts_vars.alarm_sendings.keys():
-#         if "SOURCE" in shield:
-#             continue
-#         assert bad_hosts_vars.alarm_sendings[shield] is True
-#
-#     rematched_message = auditor.form_alarm_message()
-#     assert not rematched_message
-#
-#     twice_sent_message = auditor.send_messages(rematched_message)
-#     assert twice_sent_message is False
-#
-#     for shield in bad_hosts_vars.hosts.keys():
-#         auditor.power_on_shields.update({shield: True})
-#
-#     assert all(auditor.power_on_shields.values()) is True
-#
-#     cancel_message = auditor.form_cancel_message()
-#     assert cancel_message
-#
-#     for shield in bad_hosts_vars.hosts.keys():
-#         if "SOURCE" in shield:
-#             continue
-#         assert bad_hosts_vars.cancel_messages[shield] in cancel_message
-#         assert bad_hosts_vars.cancel_sendings[shield] is False
-#
-#     once_sent_message = auditor.send_messages(cancel_message)
-#     assert once_sent_message is True
-#
-#     auditor.set_cancel_sending_status()
-#
-#     for shield in bad_hosts_vars.cancel_sendings.keys():
-#         if "SOURCE" in shield:
-#             continue
-#         assert bad_hosts_vars.cancel_sendings[shield] is True
-#
-#     rematched_message = auditor.form_cancel_message()
-#     assert not rematched_message
-#
-#     twice_sent_message = auditor.send_messages(rematched_message)
-#     assert twice_sent_message is False
+@pytest.mark.skipif(
+    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="No credentials on GitHub"
+)
+def test_cancel_messages_right_and_sent(bad_hosts_vars: Vars) -> None:
+    """
+    Sets all the test hosts as unreached and available again.
+    Just sets without pinging.
+    Checks the result message has been sent.
+    Checks the sent message doesn't send twice.
+    """
+    auditor = AuditShields(bad_hosts_vars)
+
+    for shield in bad_hosts_vars.hosts.keys():
+        auditor.power_off_shields.update({shield: True})
+
+    assert all(auditor.power_off_shields.values()) is True
+
+    alarm_message = auditor.form_alarm_message()
+    assert alarm_message
+
+    first_alarm_message = auditor.send_messages(alarm_message)
+    assert first_alarm_message is True
+
+    auditor.set_alarm_sending_status()
+
+    for shield in bad_hosts_vars.alarm_sendings.keys():
+        if "SOURCE" in shield:
+            continue
+        assert bad_hosts_vars.alarm_sendings[shield] is True
+
+    rematched_message = auditor.form_alarm_message()
+    assert not rematched_message
+
+    second_alarm_message = auditor.send_messages(rematched_message)
+    assert second_alarm_message is False
+
+    for shield in bad_hosts_vars.hosts.keys():
+        auditor.power_on_shields.update({shield: True})
+
+    assert all(auditor.power_on_shields.values()) is True
+
+    cancel_message = auditor.form_cancel_message()
+    assert cancel_message
+
+    first_cancel_message = auditor.send_messages(cancel_message)
+    assert first_cancel_message is True
+
+    auditor.set_cancel_sending_status()
+
+    for shield in bad_hosts_vars.cancel_sendings.keys():
+        if "SOURCE" in shield:
+            continue
+        assert bad_hosts_vars.cancel_sendings[shield] is True
+
+    rematched_message = auditor.form_cancel_message()
+    assert not rematched_message
+
+    second_cancel_message = auditor.send_messages(rematched_message)
+    assert second_cancel_message is False

--- a/tests/test_6_check_messages.py
+++ b/tests/test_6_check_messages.py
@@ -1,6 +1,9 @@
-"""Telegram and Viber bots checking."""
+"""Checking the completeness of messages and their sending."""
+
+import pytest
 
 from app.audit import AuditShields
+from app.dirs import DIR_ROOT, GITHUB_ROOTDIR
 from app.vars import Vars
 
 
@@ -46,3 +49,90 @@ def test_cancel_message_is_full(config_vars_set: Vars) -> None:
 
     for shield in config_vars_set.hosts.keys():
         assert config_vars_set.cancel_messages[shield] in cancel_message
+
+
+@pytest.mark.skipif(
+    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="Denied pinging from GitHub"
+)
+def test_emergency_message_sent(bad_hosts_vars: Vars) -> None:
+    """
+    Checks all the test hosts are unreached.
+    Checks the ping command number is equal the hosts number.
+    Checks the result message has been sent.
+    Checks that the message once sent, doesn't send twice.
+    """
+    auditor = AuditShields(bad_hosts_vars)
+    assert all(auditor.power_off_shields.values()) is False
+
+    for net in bad_hosts_vars.nets:
+        if not auditor.is_network_out(net):
+            auditor.check_shields(net)
+
+    assert all(auditor.power_off_shields.values()) is True
+
+    alarm_message = auditor.form_alarm_message()
+    assert alarm_message
+
+    all_hosts_list = [
+        hosts
+        for hosts in bad_hosts_vars.hosts.values()
+        if "IN_TOUCH" not in hosts.keys()
+    ]
+
+    all_hosts_number = sum(len(host) for host in all_hosts_list)
+    assert auditor.pinged_hosts == all_hosts_number
+
+    first_alarm_message = auditor.send_messages(alarm_message)
+    assert first_alarm_message is True
+
+    status = auditor.set_alarm_sending_status()
+    assert status is True
+
+    for shield in bad_hosts_vars.alarm_sendings.keys():
+        if "SOURCE" in shield:
+            continue
+        assert bad_hosts_vars.alarm_sendings[shield] is True
+
+    rematched_message = auditor.form_alarm_message()
+    assert not rematched_message
+
+    second_alarm_message = auditor.send_messages(rematched_message)
+    assert second_alarm_message is False
+
+
+@pytest.mark.skipif(
+    GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="No credentials on GitHub"
+)
+def test_cancel_message_sent(bad_hosts_vars: Vars) -> None:
+    """
+    Sets all the test hosts status as if they are available again.
+    Just setting without pinging.
+    Checks the result message has been sent.
+    Checks that the message, once sent doesn't send twice.
+    """
+    auditor = AuditShields(bad_hosts_vars)
+
+    for shield in bad_hosts_vars.hosts.keys():
+        auditor.power_on_shields.update({shield: True})
+
+    assert all(auditor.power_on_shields.values()) is True
+
+    cancel_message = auditor.form_cancel_message()
+    assert cancel_message
+
+    first_cancel_message = auditor.send_messages(cancel_message)
+    assert first_cancel_message is True
+
+    status = auditor.set_cancel_sending_status()
+    assert status is True
+
+    for shield in bad_hosts_vars.cancel_sendings.keys():
+        if "SOURCE" in shield:
+            continue
+        assert bad_hosts_vars.cancel_sendings[shield] is True
+
+    rematched_message = auditor.form_cancel_message()
+    assert not rematched_message
+
+    second_cancel_message = auditor.send_messages(rematched_message)
+    assert second_cancel_message is False

--- a/tests/test_6_check_messages.py
+++ b/tests/test_6_check_messages.py
@@ -1,0 +1,42 @@
+"""Telegram and Viber bots checking."""
+
+from app.audit import AuditShields
+from app.vars import Vars
+
+
+def test_alarm_message_is_full(config_vars_set: Vars) -> None:
+    """
+    Sets the sources' power statuses as if they're off.
+    Forms an alarm message.
+    Ensures all the powered-off items are included in the message.
+    """
+    auditor = AuditShields(config_vars_set)
+
+    auditor.power_off_shields = {
+        source: True for source in config_vars_set.hosts.keys()
+    }
+
+    result_message = auditor.form_alarm_message()
+    assert result_message
+
+    for shield in config_vars_set.hosts.keys():
+        assert config_vars_set.alarm_messages[shield] in result_message
+
+
+def test_cancel_message_is_full(config_vars_set: Vars) -> None:
+    """
+    Sets the sources' power statuses as if they're on.
+    Forms a cancel message.
+    Ensures all the powered-on items are included in the message.
+    """
+    auditor = AuditShields(config_vars_set)
+
+    auditor.power_on_shields = {
+        source: True for source in config_vars_set.hosts.keys()
+    }
+
+    result_message = auditor.form_cancel_message()
+    assert result_message
+
+    for shield in config_vars_set.hosts.keys():
+        assert config_vars_set.cancel_messages[shield] in result_message

--- a/tests/test_6_check_messages.py
+++ b/tests/test_6_check_messages.py
@@ -12,15 +12,18 @@ def test_alarm_message_is_full(config_vars_set: Vars) -> None:
     """
     auditor = AuditShields(config_vars_set)
 
+    alarm_message = auditor.form_alarm_message()
+    assert not alarm_message
+
     auditor.power_off_shields = {
         source: True for source in config_vars_set.hosts.keys()
     }
 
-    result_message = auditor.form_alarm_message()
-    assert result_message
+    alarm_message = auditor.form_alarm_message()
+    assert alarm_message
 
     for shield in config_vars_set.hosts.keys():
-        assert config_vars_set.alarm_messages[shield] in result_message
+        assert config_vars_set.alarm_messages[shield] in alarm_message
 
 
 def test_cancel_message_is_full(config_vars_set: Vars) -> None:
@@ -31,12 +34,15 @@ def test_cancel_message_is_full(config_vars_set: Vars) -> None:
     """
     auditor = AuditShields(config_vars_set)
 
+    cancel_message = auditor.form_cancel_message()
+    assert not cancel_message
+
     auditor.power_on_shields = {
         source: True for source in config_vars_set.hosts.keys()
     }
 
-    result_message = auditor.form_cancel_message()
-    assert result_message
+    cancel_message = auditor.form_cancel_message()
+    assert cancel_message
 
     for shield in config_vars_set.hosts.keys():
-        assert config_vars_set.cancel_messages[shield] in result_message
+        assert config_vars_set.cancel_messages[shield] in cancel_message


### PR DESCRIPTION
#### Descripton:
- Add a check to ensure the cancel and the alarm mesages are full.
- Add a check to ensure the messages are not formed before they are set to be formed.
- Move the message's fullness checking to a separate file.
- Move the messages sending checking to the separate file. 
- Remove the message's fullness checking from another test file.
- Closes #90