### PR TITLE
Add a test to ensure the messages are not sent from 23:00 to 06:00.

### DIFF
--- a/app/audit.py
+++ b/app/audit.py
@@ -13,7 +13,10 @@ CREATE_NO_WINDOW: int = 134217728
 
 
 class AuditShields:
-    """Processes and keeps a state of the checked power shields."""
+    """
+    Processes and keeps a state
+    of the checked power shields.
+    """
 
     def __init__(self, config_vars: Vars) -> None:
         self.vars: Vars = config_vars
@@ -31,10 +34,14 @@ class AuditShields:
         self.messages_sent: dict = {}
         self.telegram_sender = MyTelegramBot(self.vars)
         self.viber_sender = MyViberBot(self.vars)
+        self.stop_delaying = False
 
     @staticmethod
     def ping_host(ip_address: str) -> bool:
-        """Pings a single host if it's up or out depending on a platform."""
+        """
+        Pings a single host if it's up
+        or out depending on a platform.
+        """
 
         command = [
             "ping",
@@ -73,7 +80,10 @@ class AuditShields:
         return True
 
     def is_network_out(self, network: str) -> bool:
-        """Checks an always working host to make sure its network works."""
+        """
+        Checks an always working host
+        to make sure its network works.
+        """
 
         checking_host_ip = self.vars.hosts[f"{network} SOURCE"]["IN_TOUCH"]
         is_host_out = self.ping_host(checking_host_ip)
@@ -110,7 +120,10 @@ class AuditShields:
         return self.power_off_shields
 
     def form_alarm_message(self) -> str:
-        """Composes an alarm message regarding the certain equipment alarm."""
+        """
+        Composes an alarm message
+        regarding the certain equipment alarm.
+        """
 
         message_text = ""
         for shield, status in self.power_off_shields.items():
@@ -123,7 +136,8 @@ class AuditShields:
     def form_cancel_message(self) -> str:
         """
         Composes a cancel message regarding
-        the certain equipment alarm restoring."""
+        the certain equipment alarm restoring.
+        """
 
         message_text = ""
         for shield, status in self.power_on_shields.items():
@@ -134,7 +148,10 @@ class AuditShields:
         return message_text
 
     def send_messages(self, text: str) -> bool:
-        """Sends the alarm message to proper Telegram and Viber users."""
+        """
+        Sends the alarm message
+        to proper Telegram and Viber users.
+        """
 
         if_any_bot = any([self.telegram_sender.set, self.viber_sender.set])
         messages_are_sent = []
@@ -157,18 +174,19 @@ class AuditShields:
 
         return False
 
-    @staticmethod
-    def delay_sending():
+    def delay_sending(self):
         """
         Delays a message sendings
         if the reason to send occurs from 23:00 to 06:00.
         """
-        send_before = datetime.time(23, 00)
         send_after = datetime.time(6, 00)
+        send_before = datetime.time(23, 00)
         while True:
             time_now = datetime.datetime.now().time()
             if send_after < time_now < send_before:
-                break
+                return True
+            if self.stop_delaying:
+                return False
             time.sleep(60)
 
     def set_alarm_sending_status(self) -> bool:

--- a/tests/test_6_check_messages.py
+++ b/tests/test_6_check_messages.py
@@ -1,5 +1,8 @@
 """Checking the completeness of messages and their sending."""
 
+import datetime
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from app.audit import AuditShields
@@ -54,7 +57,7 @@ def test_cancel_message_is_full(config_vars_set: Vars) -> None:
 @pytest.mark.skipif(
     GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="Denied pinging from GitHub."
 )
-def test_emergency_message_sent(bad_hosts_vars: Vars) -> None:
+def test_emergency_message_is_sent(bad_hosts_vars: Vars) -> None:
     """
     Checks all the test hosts are unreached.
     Checks the ping command number is equal the hosts number.
@@ -103,7 +106,7 @@ def test_emergency_message_sent(bad_hosts_vars: Vars) -> None:
 @pytest.mark.skipif(
     GITHUB_ROOTDIR in f"{DIR_ROOT}", reason="No secrets on GitHub."
 )
-def test_cancel_message_sent(bad_hosts_vars: Vars) -> None:
+def test_cancel_message_is_sent(bad_hosts_vars: Vars) -> None:
     """
     Sets all the test hosts status as if they are available again.
     Just setting without pinging.
@@ -136,3 +139,53 @@ def test_cancel_message_sent(bad_hosts_vars: Vars) -> None:
 
     second_cancel_message = auditor.send_messages(rematched_message)
     assert second_cancel_message is False
+
+
+def test_message_is_sent_only_during_the_day(bad_hosts_vars) -> None:
+    """
+    Checks that a message is sent
+    only between 06:00 and 23:00.
+    """
+
+    msg_text = "Testing. It's not a night now,"
+    auditor = AuditShields(bad_hosts_vars)
+
+    time_now = datetime.datetime.now().time()
+    send_after = datetime.time(6, 0)
+    send_before = datetime.time(23, 0)
+
+    if send_after < time_now < send_before:
+
+        message_is_not_delayed = auditor.delay_sending()
+        message_is_sent = auditor.send_messages(msg_text)
+
+        assert message_is_not_delayed
+        assert message_is_sent
+
+
+def test_sending_delay_works_fine_at_night(bad_hosts_vars):
+    """
+    Checks that a message is sent
+    only between 06:00 and 23:00
+    because of the delay is working.
+    """
+
+    auditor = AuditShields(bad_hosts_vars)
+
+    time_now = datetime.datetime.now().time()
+    send_after = datetime.time(6, 00)
+    send_before = datetime.time(23, 0)
+
+    if send_after > time_now > send_before:
+
+        with pytest.raises(TimeoutError) as err:
+            executor = ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(auditor.delay_sending)
+            future.result(timeout=4)
+
+        assert isinstance(err, pytest.ExceptionInfo)
+
+        auditor.stop_delaying = True
+
+        message_is_delayed = auditor.delay_sending()
+        assert not message_is_delayed

--- a/tests/test_6_check_messages.py
+++ b/tests/test_6_check_messages.py
@@ -163,7 +163,7 @@ def test_message_is_sent_only_during_the_day(bad_hosts_vars) -> None:
         assert message_is_sent
 
 
-def test_sending_delay_works_fine_at_night(bad_hosts_vars):
+def test_sending_delay_works_fine_at_night(bad_hosts_vars) -> None:
     """
     Checks that a message is sent
     only between 06:00 and 23:00


### PR DESCRIPTION
#### Description:
- Add new 'AuditShields' attribute called 'stop_delaying' to stop the endless loop for tests.
- Add a check to ensure the message can be sent between 06:00 and 23:00
- Add  a check to ensure the message can't be sent after 23:00 untill 06:00
- Close #100